### PR TITLE
feat(v1.1.0): add portfolio holdings import to Google Sheets

### DIFF
--- a/portfolio_tool_scripts/README.md
+++ b/portfolio_tool_scripts/README.md
@@ -32,6 +32,30 @@ Filter and Sort by Pay Date
 This is the script that will populate the portfolio holdings into the `Holdings` sheet.
 The portfolio holdings are easily copied from the Personal Capital Website using the Tampermonkey script with a click of a button.
 
+### Google Sheet Formulas
+
+Setup Projected Annual Income Table
+
+For Annual Income
+
+`=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)`
+
+For Monthly Average Income
+
+`=AnnualIncomeResult/12` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/12`
+
+For Weekly Average Income
+
+`=AnnualIncomeResult/52` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/52`
+
+For Daily Average Income
+
+`=AnnualIncomeResult/365` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/365`
+
+For Hourly Average Income
+
+`=AnnualIncomeResult/8760` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/8760`
+
 ## utilities.gs
 
 This is the script that will hold any common functionality that could be reused by other scripts.

--- a/portfolio_tool_scripts/README.md
+++ b/portfolio_tool_scripts/README.md
@@ -27,3 +27,11 @@ Filter and Sort by Pay Date
 
 `=QUERY(latest_dividends!A:I, "SELECT A,E,D,B WHERE D IS NOT NULL AND E >= date'"&TEXT(TODAY(),"yyyy-mm-dd")&"' ORDER BY D",-1)`
 
+## populate_holdings.gs
+
+This is the script that will populate the portfolio holdings into the `Holdings` sheet.
+The portfolio holdings are easily copied from the Personal Capital Website using the Tampermonkey script with a click of a button.
+
+## utilities.gs
+
+This is the script that will hold any common functionality that could be reused by other scripts.

--- a/portfolio_tool_scripts/README.md
+++ b/portfolio_tool_scripts/README.md
@@ -36,23 +36,23 @@ The portfolio holdings are easily copied from the Personal Capital Website using
 
 Setup Projected Annual Income Table
 
-For Annual Income
+For Annual Dividend Income
 
 `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)`
 
-For Monthly Average Income
+For Monthly Average Dividend Income
 
 `=AnnualIncomeResult/12` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/12`
 
-For Weekly Average Income
+For Weekly Average Dividend Income
 
 `=AnnualIncomeResult/52` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/52`
 
-For Daily Average Income
+For Daily Average Dividend Income
 
 `=AnnualIncomeResult/365` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/365`
 
-For Hourly Average Income
+For Hourly Average Dividend Income
 
 `=AnnualIncomeResult/8760` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/8760`
 

--- a/portfolio_tool_scripts/main.gs
+++ b/portfolio_tool_scripts/main.gs
@@ -1,11 +1,14 @@
 var SPREADSHEET_ID = "UPDATE THIS WITH YOUR GOOGLE SHEET ID";
 var TICKER_SHEET_NAME = "tickers";
 var DIVIDEND_SHEET_NAME = "latest_dividends";
+var HOLDINGS_SHEET_NAME = "Holdings";
+var SETTINGS_SHEET_NAME = "Settings";
 
 
 function initMenu() {
     var ui = SpreadsheetApp.getUi();
     var menu = ui.createMenu("Portfolio Tools");
+    menu.addItem("Update Portfolio Holdings", "populate_holdings");
     menu.addItem("Get Latest Dividends", "get_latest_dividends");
     menu.addToUi();
 }

--- a/portfolio_tool_scripts/populate_holdings.gs
+++ b/portfolio_tool_scripts/populate_holdings.gs
@@ -1,0 +1,78 @@
+function populate_holdings() {
+  Logger.log("Populating Holdings")
+
+  var settings = get_settings();
+  var holdings = JSON.parse(settings["Portfolio Holdings"])["holdings"];
+
+  var excluded_holdings = settings["Dividend Suspended Holdings"].split(',');
+  Logger.log("Holdings to exclude:");
+  Logger.log(excluded_holdings);
+
+
+  var latest_div_data = get_latest_dividends_data();
+
+  for (var i=0; i < holdings.length; i++) {
+    ticker_name = holdings[i]["Holding"];
+
+    annual_payout = latest_div_data[ticker_name] != null ? latest_div_data[ticker_name]["AnnualPayout"] : 0;
+    holdings[i]["Annual Payout"] = annual_payout;
+
+    dividend_payout = latest_div_data[ticker_name] != null ? latest_div_data[ticker_name]["DividendAmount"] : 0;
+    holdings[i]["Dividend Amount"] = dividend_payout;
+
+    holdings[i]["Projected Payout"] = holdings[i]["Shares"] * holdings[i]["Annual Payout"];
+
+    if(excluded_holdings.indexOf(ticker_name) > -1) {
+      holdings[i]["Dividend Suspended"] = true;
+    }
+    else
+    {
+      holdings[i]["Dividend Suspended"] = false;
+    }
+  }
+
+  //Writing to holdings spreadsheet
+  var ws = get_sheet_object(HOLDINGS_SHEET_NAME);
+  ws.getRange("A:J").clear();
+
+  var headerRow = Object.keys(holdings[0]);
+  ws.appendRow(headerRow);
+
+  for (var i=0; i < holdings.length; i++) {
+    var headerRow = Object.keys(holdings[0]);
+    var row = headerRow.map(function(key){ return holdings[i][key]});
+    ws.appendRow(row);
+  }
+
+  //Set columns to currency format
+  var columns = ws.getRange(2,3, ws.getRange("C2").getDataRegion().getLastRow(), ws.getRange("C2").getDataRegion().getLastColumn());
+  columns.setNumberFormat("$#,##0.00;$(#,##0.00)");
+
+}
+
+function get_latest_dividends_data() {
+  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  var ws = ss.getSheetByName(DIVIDEND_SHEET_NAME);
+
+  var header_list = ws.getRange(1,1, 1, ws.getRange("A1").getDataRegion().getLastColumn()).getValues()[0];
+
+  var ticker_row_list = ws.getRange(2,1, ws.getRange("A2").getDataRegion().getLastRow(), 12).getValues();
+
+  var ticker_data = {};
+
+  for (var i=0; i < ticker_row_list.length; i++) {
+
+    var ticker = ticker_row_list[i];
+    var ticker_name = ticker[0];
+    ticker_data[ticker_name] = {};
+
+    for (var j=1; j < ticker.length; j++) {
+      var key = header_list[j];
+      var value = ticker[j];
+
+      ticker_data[ticker_name][key] = value;
+    }
+  }
+
+  return ticker_data
+}

--- a/portfolio_tool_scripts/utilities.gs
+++ b/portfolio_tool_scripts/utilities.gs
@@ -1,0 +1,23 @@
+function get_settings() {
+  var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  var ws = ss.getSheetByName(SETTINGS_SHEET_NAME);
+
+  var values = ws.getRange(2,1, ws.getRange("A2").getDataRegion().getLastRow(), 2).getValues();
+  var settings = convert_to_dictionary(values);
+  return settings
+}
+
+function convert_to_dictionary(spreadsheet_data) {
+  var dictionary = {};
+
+  for (var i=0; i < spreadsheet_data.length; i++) {
+
+    var key = spreadsheet_data[i][0];
+    var value = spreadsheet_data[i][1];
+
+    dictionary[key] = value;
+  }
+
+  return dictionary
+
+}

--- a/tampermonkey_scripts/README.md
+++ b/tampermonkey_scripts/README.md
@@ -1,0 +1,11 @@
+# All Information For Each Tampermonkey Script
+
+This will provide some detailed information for each script in this directory.
+
+## personal_capital_brokerage_holdings_getter.js
+
+This script will run on the Personal Capital Website and place a green `Copy Holdings` button on
+the `Holdings` tab of the brokerage account that you want to copy from. When the button is clicked,
+the button will copy the holdings into JSON data to your clipboard which can then be pasted into
+the GoogleSheets or any other program that wants to use the JSON data.
+

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -1,0 +1,118 @@
+// ==UserScript==
+// @name         Personal Capital Holdings Getter
+// @namespace    http://tampermonkey.net/
+// @version      1.0
+// @description  This will create a button on the holdings tab so that the current positions can be copied to the clipboard as JSON for easy import to GoogleSheets or any other program!
+// @author       Coding Sensei
+// @include      /^https://home\.personalcapital\.com/page/login/app*/
+// @require      http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js
+// @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
+// @grant        none
+// ==/UserScript==
+
+
+let styleSheet = `
+.copyBtn {
+    background-color: green;
+    padding: 5px;
+    font-size: 12px;
+}
+`;
+
+let s = document.createElement('style');
+s.type = "text/css";
+s.innerHTML = styleSheet;
+(document.head || document.documentElement).appendChild(s);
+
+
+function get_list_of_headers(headers_data) {
+    var all_headers = [];
+    for (const header of headers_data.childNodes) {
+        all_headers.push(header.text);
+    }
+
+    return all_headers
+}
+
+function populate_ticker_map(headers, ticker_data) {
+    var info = new Map();
+
+    for (const data of ticker_data.childNodes) {
+        var text = data.childNodes[0].textContent;
+        info.set(headers.shift(), text);
+    }
+
+    return info
+}
+
+function get_table_holdings() {
+
+    let holdingsTable = document.getElementsByClassName("table table--hoverable table--primary table__body--primary pc-holdings-grid qa-datagrid-rows centi pc-holdings-grid--account-details table--actionable")[0];
+
+    console.log(holdingsTable);
+
+    var headers = get_list_of_headers(holdingsTable.childNodes[0]);
+    let rows = holdingsTable.childNodes[1];
+    let summary = holdingsTable.childNodes[2];
+
+
+    var holdings = [];
+
+    for (const row of rows.childNodes) {
+        var ticker_map = populate_ticker_map(headers.slice(0), row);
+        holdings.push(ticker_map);
+    }
+
+    console.log(holdings);
+    console.log(convert_holdings_to_json(holdings));
+
+    return holdings
+}
+
+function mapToObj (map) {
+    return [...map].reduce((acc, val) => {
+        acc[val[0]] = val[1];
+        return acc;
+    }, {});
+}
+
+function convert_holdings_to_json(positions) {
+    var json_holdings = {
+        holdings:[]
+    };
+    for (const stock of positions) {
+        json_holdings.holdings.push(mapToObj(stock));
+    }
+
+    return JSON.stringify(json_holdings)
+}
+
+function copy() {
+    let temp = document.createElement('textarea');
+    document.body.appendChild(temp);
+    var holdings = get_table_holdings();
+    temp.value = convert_holdings_to_json(holdings);
+    temp.select();
+    document.execCommand('copy');
+    temp.remove();
+}
+
+function add_copy_button() {
+    let searchObj = document.getElementsByClassName("pc-input-group  pc-input-group--with-prefix")[0];
+    let btn = document.createElement("button");
+    btn.innerHTML = "Copy Holdings";
+    btn.className = "copyBtn";
+    btn.onclick = () => {
+        copy()
+        alert("Finished copying");
+    }
+    console.log(searchObj);
+
+    searchObj.insertBefore(btn, searchObj[0]);
+}
+
+waitForKeyElements (
+    "#accountDetails > div > div.appTemplate > div.datagridSection > div > div.pc-search-input.pc-u-pl-",
+    add_copy_button,
+    false
+);


### PR DESCRIPTION
These changes will be released as `v1.1.0` to follow the new convention that we started with the last release. 
Here are the functionalities included in this release:

Add scripts to allow the import of your portfolio holdings into Google Sheets.

1. Google Sheets will now have a `Settings` sheet that will allow us to customize many settings (in the future) like the currently ones added are:

      1. `Portfolio Holdings`: This settings is to hold the latest JSON data of your portfolio that is retrieved from Personal Capital using the Tampermonkey script.
      2. `Dividend Suspended Holdings`: This setting is used for controlling which companies should be set as suspended dividend paying companies. The current use is for excluding Projected Annual Dividend Income on these companies, but I could see this being very useful for other use cases in the future.

2. Google Sheets will now have a `Holdings` sheet that will contain all of the information from your portfolio holdings. This will include various information like the following: 
     1. Holding Name
     2. Amount of Shares
     3. Value
     4. Annual Payout
     5. Projected Payout
     6. Dividend Suspended (This is set to `True` if the ticker name was set in the `Dividend Suspended Holdings` of the `Settings` sheet)
     7. And many more

3. The `Portfolio Tools` button at the top of the Google Sheets will now have an `Update Portfolio Holdings` which will update the `Holdings` sheet (See Above new feature # 2) with the new information in the `Settings` sheet -> `Portfolio Holdings`. The current workflow for this version of the scripts is to do the following:
    1. Go to Personal Capital -> Login -> Go Brokerage Account
    2. You'll want to go to the `Holdings` tab of the Brokerage Account in Personal Capital
    3. Tampermonkey will be running after the page loads and you should see a green `Copy Holdings` button
    4. Click the green button -> This will copy the holdings into your clipboard (You'll get an alert pop when it's copied)
    5. Go to the Google Sheets -> `Settings` sheet
    6. Right-click paste or CTRL + v and paste it on `Portfolio Holdings`
    7. Click on the `Portfolio Tools` at the top of the Google Sheets
    8. Finally click the `Update Portfolio Holdings` option and this will updated your holdings

4. Add a Tampermonkey script that will allow the copy of your holdings of a brokerage account on Personal Capital to your clipboard. More information from the README.md in the `tampermonkey_scripts`

    > This script will run on the Personal Capital Website and place a green `Copy Holdings` button on
the `Holdings` tab of the brokerage account that you want to copy from. When the button is clicked,
the button will copy the holdings into JSON data to your clipboard which can then be pasted into
the GoogleSheets or any other program that wants to use the JSON data.

Links:
Personal Capital: https://www.personalcapital.com/ (Signup with the person that introduced me to Personal Capital, You'll get $20 and he will get $20 https://bit.ly/2JcmrSS) I can't use my own referral link since I don't want my name shown so you can just support me by following my [YouTube channel](https://www.youtube.com/c/InvestingSensei)
Tampermonkey: https://www.tampermonkey.net/