### PR TITLE
fix(latest_dividends): allow the support for tickers ending with .DE, .OL etc

### DIFF
--- a/portfolio_tool_scripts/get_latest_dividends.gs
+++ b/portfolio_tool_scripts/get_latest_dividends.gs
@@ -154,7 +154,15 @@ function write_to_sheet(json) {
     if (json.CashDividends.length == 0) {
         return
     }
-    var ticker = json.Security.Symbol;
+
+    var ticker = "";
+    if (json.IdentifierType == "Symbol") {
+      ticker = json.Identifier;
+    }
+    else {
+      ticker = json.Security.Symbol;
+    }
+    
     var json = json.CashDividends;
     var ws = get_sheet_object(DIVIDEND_SHEET_NAME);
 

--- a/portfolio_tool_scripts/get_latest_dividends.gs
+++ b/portfolio_tool_scripts/get_latest_dividends.gs
@@ -62,13 +62,14 @@ function get_stock_history(token, ticker) {
 
 function clear_sheet() {
     var ws = get_sheet_object(DIVIDEND_SHEET_NAME);
-    ws.getRange("A:O").clear();
+    ws.getRange("A:O").clearContent();
 }
 
 function create_header(ticker_data) {
     var ws = get_sheet_object(DIVIDEND_SHEET_NAME);
     var headerRow = Object.keys(ticker_data.CashDividends[0]);
     headerRow.unshift("Ticker");
+    headerRow.push("Name");
     ws.appendRow(headerRow);
 }
 
@@ -156,6 +157,7 @@ function write_to_sheet(json) {
     }
     var ticker = json.Security.Symbol;
     var json = json.CashDividends;
+    var name = json.Security.Name;
     var ws = get_sheet_object(DIVIDEND_SHEET_NAME);
 
 
@@ -165,6 +167,7 @@ function write_to_sheet(json) {
             return json[i][key]
         });
         row.unshift(ticker);
+        row.push(name);
         ws.appendRow(row);
     }
 

--- a/portfolio_tool_scripts/get_latest_dividends.gs
+++ b/portfolio_tool_scripts/get_latest_dividends.gs
@@ -163,16 +163,15 @@ function write_to_sheet(json) {
     else {
       ticker = json.Security.Symbol;
     }
-    
-    var json = json.CashDividends;
+
     var name = json.Security.Name;
+    var json_cash_dividends = json.CashDividends;
     var ws = get_sheet_object(DIVIDEND_SHEET_NAME);
 
-
-    for (var i = 0; i < json.length; i++) {
-        var headerRow = Object.keys(json[0]);
+    for (var i = 0; i < json_cash_dividends.length; i++) {
+        var headerRow = Object.keys(json_cash_dividends[0]);
         var row = headerRow.map(function(key) {
-            return json[i][key]
+            return json_cash_dividends[i][key]
         });
         row.unshift(ticker);
         row.push(name);

--- a/portfolio_tool_scripts/populate_holdings.gs
+++ b/portfolio_tool_scripts/populate_holdings.gs
@@ -56,7 +56,7 @@ function get_latest_dividends_data() {
 
   var header_list = ws.getRange(1,1, 1, ws.getRange("A1").getDataRegion().getLastColumn()).getValues()[0];
 
-  var ticker_row_list = ws.getRange(2,1, ws.getRange("A2").getDataRegion().getLastRow(), 12).getValues();
+  var ticker_row_list = ws.getRange(2,1, ws.getRange("A2").getDataRegion().getLastRow(), header_list.length).getValues();
 
   var ticker_data = {};
 


### PR DESCRIPTION
	"Security": {
		"CompositeFIGI": "BBG000BBPTP4",
		"Industry": "MajorTelecommunications",
		"Sector": "Communications",
		"MarketIdentificationCode": "XOSL",
		"Market": "Oslo Bors ASA",
		"InstrumentClass": "Stock",
		"Name": "Telenor ASA",
		"FIGI": "BBG000BBPV51",
		"SEDOL": null,
		"Valoren": "1160189",
		"ISIN": null,
		"Symbol": "TEL",
		"CUSIP": null,
		"CIK": "0001126113"
	},
	"EndDate": "2029-12-30",
	"StartDate": "2007-01-01",
	"IdentifierAsOfDate": "",
	"IdentifierType": "Symbol",
	"Identifier": "TEL.OL",
	"CorporateActionsAdjusted": "true",
	"Identity": "Request",
	"Message": null
}

For stocks ending with .DE .OL and so on, using Security.Symbol will return wrong identifier. Changing to Identifier will return correct symbol for the stock.

I've added a check for IdentifierType, fallback to Security.Symbol.

Change to clearContent() so it does not delete conditional formatting
Change get dividends to use header row length instead of hard coded number of columns
Also added short name for stock