### PR TITLE
feat(PC): add getting of all holdings account

### DIFF
--- a/portfolio_tool_scripts/populate_holdings.gs
+++ b/portfolio_tool_scripts/populate_holdings.gs
@@ -33,7 +33,7 @@ function populate_holdings() {
 
   //Writing to holdings spreadsheet
   var ws = get_sheet_object(HOLDINGS_SHEET_NAME);
-  ws.getRange("A:J").clear();
+  ws.getRange("A:K").clear();
 
   var headerRow = Object.keys(holdings[0]);
   ws.appendRow(headerRow);

--- a/portfolio_tool_scripts/populate_holdings.gs
+++ b/portfolio_tool_scripts/populate_holdings.gs
@@ -29,6 +29,8 @@ function populate_holdings() {
     {
       holdings[i]["Dividend Suspended"] = false;
     }
+
+    delete holdings[i]["Change"];
   }
 
   //Writing to holdings spreadsheet

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Personal Capital Holdings Getter
 // @namespace    http://tampermonkey.net/
-// @version      1.0
+// @version      1.1.0
 // @description  This will create a button on the holdings tab so that the current positions can be copied to the clipboard as JSON for easy import to GoogleSheets or any other program!
 // @author       Coding Sensei
 // @include      /^https://home\.personalcapital\.com/page/login/app*/
@@ -45,9 +45,9 @@ function populate_ticker_map(headers, ticker_data) {
     return info
 }
 
-function get_table_holdings() {
+function get_table_holdings(class_name_element) {
 
-    let holdingsTable = document.getElementsByClassName("table table--hoverable table--primary table__body--primary pc-holdings-grid qa-datagrid-rows centi pc-holdings-grid--account-details table--actionable")[0];
+    let holdingsTable = document.getElementsByClassName(class_name_element)[0];
 
     console.log(holdingsTable);
 
@@ -87,23 +87,13 @@ function convert_holdings_to_json(positions) {
     return JSON.stringify(json_holdings)
 }
 
-function copy() {
-    let temp = document.createElement('textarea');
-    document.body.appendChild(temp);
-    var holdings = get_table_holdings();
-    temp.value = convert_holdings_to_json(holdings);
-    temp.select();
-    document.execCommand('copy');
-    temp.remove();
-}
-
-function add_copy_button() {
+function add_copy_button(function_call_on_click) {
     let searchObj = document.getElementsByClassName("pc-input-group  pc-input-group--with-prefix")[0];
     let btn = document.createElement("button");
     btn.innerHTML = "Copy Holdings";
     btn.className = "copyBtn";
     btn.onclick = () => {
-        copy()
+        function_call_on_click()
         alert("Finished copying");
     }
     console.log(searchObj);
@@ -111,8 +101,45 @@ function add_copy_button() {
     searchObj.insertBefore(btn, searchObj[0]);
 }
 
+function copy_single_holdings_account() {
+    var html_table_element = "table table--hoverable table--primary table__body--primary pc-holdings-grid qa-datagrid-rows centi pc-holdings-grid--account-details table--actionable";
+    let temp = document.createElement('textarea');
+    document.body.appendChild(temp);
+    var holdings = get_table_holdings(html_table_element);
+    temp.value = convert_holdings_to_json(holdings);
+    temp.select();
+    document.execCommand('copy');
+    temp.remove();
+}
+
+function copy_all_holdings_account() {
+    var html_table_element = "table table--hoverable table--primary table__body--primary pc-holdings-grid qa-datagrid-rows centi  table--actionable";
+    let temp = document.createElement('textarea');
+    document.body.appendChild(temp);
+    var holdings = get_table_holdings(html_table_element);
+    temp.value = convert_holdings_to_json(holdings);
+    temp.select();
+    document.execCommand('copy');
+    temp.remove();
+}
+
+function create_single_account_copy_button() {
+    add_copy_button(copy_single_holdings_account)
+}
+
+function create_all_account_copy_button() {
+    add_copy_button(copy_all_holdings_account)
+}
+
 waitForKeyElements (
     "#accountDetails > div > div.appTemplate > div.datagridSection > div > div.pc-search-input.pc-u-pl-",
-    add_copy_button,
+    create_single_account_copy_button,
     false
 );
+
+waitForKeyElements (
+    "#holdings > div > div.gridFrame.offset > div > div.pc-search-input.pc-u-pl-",
+    create_all_account_copy_button,
+    false
+);
+


### PR DESCRIPTION
The changes for this PR allow the functionality to grab your holdings from multiple accounts on Personal Capital. Previously you could only export your holdings from one account like
![image](https://user-images.githubusercontent.com/55446606/110473688-6e647000-80a4-11eb-8376-5dad9f60f35e.png)

With these changes you can now export from Personal Capital Top Bar -> Investing -> Holdings and now you should see a green `Copy Holdings` button that will allow you to export all/selected accounts.

![image](https://user-images.githubusercontent.com/55446606/110474147-f21e5c80-80a4-11eb-86ca-db769a74de6d.png)

