### PR TITLE
feat(tamperMonkeyScript): add M1 Finance Activity Dividend Calculator

### DIFF
--- a/tampermonkey_scripts/README.md
+++ b/tampermonkey_scripts/README.md
@@ -6,6 +6,16 @@ This will provide some detailed information for each script in this directory.
 
 This script will run on the M1 Finance Website in the Activity section and place a green `Calculate Dividends` button.
 When the button is clicked, the button will show an alert with the total amount of dividends for that activity page.
+Here is the location where the button is placed in the `Activity` section:
+
+![image](https://user-images.githubusercontent.com/55446606/113147629-8ee09f80-91f6-11eb-9ed2-80cc33ced9d9.png)
+
+Here is the Alert pop up that is received after clicking the button:
+
+![image](https://user-images.githubusercontent.com/55446606/113147693-a61f8d00-91f6-11eb-8f64-5d15a8748b73.png)
+
+One thing to note is if you are not seeing the button show up, then you need to be logged into M1 Finance and be in the `Activity` section and just refresh the page.
+That should show up the button.
 
 ## personal_capital_brokerage_holdings_getter.js
 

--- a/tampermonkey_scripts/README.md
+++ b/tampermonkey_scripts/README.md
@@ -2,6 +2,11 @@
 
 This will provide some detailed information for each script in this directory.
 
+## m1_finance_activity_dividend_calculator.js
+
+This script will run on the M1 Finance Website in the Activity section and place a green `Calculate Dividends` button.
+When the button is clicked, the button will show an alert with the total amount of dividends for that activity page.
+
 ## personal_capital_brokerage_holdings_getter.js
 
 This script will run on the Personal Capital Website and place a green `Copy Holdings` button on
@@ -11,10 +16,10 @@ the GoogleSheets or any other program that wants to use the JSON data.
 
 ## etoro_holdings_getter.js
 
-This script will run on etoro.com/portfolio and place a grey `Copy Holdings` button next to navbar buttons. 
-When the button is clicked, the button will copy the holdings into JSON data to your clipboard which can then 
+This script will run on etoro.com/portfolio and place a grey `Copy Holdings` button next to navbar buttons.
+When the button is clicked, the button will copy the holdings into JSON data to your clipboard which can then
 be pasted into the GoogleSheets or any other program that wants to use the JSON data.
 
-###Known issues: 
+###Known issues:
 - Currency won't always calculate correct price
 - You'll not get holdings from people you're copying

--- a/tampermonkey_scripts/m1_finance_activity_dividend_calculator.js
+++ b/tampermonkey_scripts/m1_finance_activity_dividend_calculator.js
@@ -1,0 +1,125 @@
+// ==UserScript==
+// @name         M1 Finance Activities Dividend Calculator
+// @namespace    http://tampermonkey.net/
+// @version      1.0.0
+// @description  This will create a button so that it can add up all of the dividends in the activity window!
+// @author       Coding Sensei
+// @include      /^https://dashboard\.m1finance\.com/d/invest/activity
+// @require      http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js
+// @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
+// @grant        none
+// ==/UserScript==
+
+
+let styleSheet = `
+.copyBtn {
+	box-shadow:inset 0px 1px 0px 0px #caefab;
+	background:linear-gradient(to bottom, #77d42a 5%, #5cb811 100%);
+	background-color:#77d42a;
+	border-radius:6px;
+	border:1px solid #268a16;
+	display:inline-block;
+	cursor:pointer;
+	color:#306108;
+	font-family:Arial;
+	font-size:15px;
+	font-weight:bold;
+	padding:6px 24px;
+	text-decoration:none;
+	text-shadow:0px 1px 0px #aade7c;
+}
+.copyBtn:hover {
+	background:linear-gradient(to bottom, #5cb811 5%, #77d42a 100%);
+	background-color:#5cb811;
+}
+.copyBtn:active {
+	position:relative;
+	top:1px;
+}
+`;
+
+let s = document.createElement('style');
+s.type = "text/css";
+s.innerHTML = styleSheet;
+(document.head || document.documentElement).appendChild(s);
+
+function get_list_of_headers(headers_data) {
+    var all_headers = [];
+    for (const header of headers_data.childNodes) {
+        all_headers.push(header.textContent);
+    }
+
+    return all_headers
+}
+
+function populate_activity_map(headers_list, row_data) {
+    var info = new Map();
+    for (var i = 0; i < headers_list.length; i++) {
+        info.set(headers_list[i], row_data.childNodes[i].textContent);
+    }
+
+    return info
+}
+
+function get_activity_table_values(class_name_element) {
+    let holdingsTable = document.getElementsByClassName(class_name_element)[0];
+
+    var headers = get_list_of_headers(holdingsTable.childNodes[0]);
+    let rows = Array.from(holdingsTable.childNodes).slice(1);
+
+    var activities = [];
+    for (const row of rows) {
+        var activity_map = populate_activity_map(headers, row);
+        activities.push(activity_map);
+    }
+    console.log(activities);
+
+    return activities
+}
+
+function get_total_dividends_from_activities(activities) {
+    var sum = 0;
+    console.log("Debug 00");
+    for (const activity of activities) {
+        if(activity.get("Activity") == "Dividend") {
+            console.log("Adding " + activity.get("Value") + " from " + activity.get("Summary"));
+            var dividend = activity.get("Value").replace("+","").replace("$","");
+            sum = sum + parseFloat(dividend);
+            console.log("Current Total: " + sum);
+        }
+    }
+
+    return sum
+}
+
+function calculate_dividend_amount() {
+    var html_table_element = "table__StyledGridTable-ju5h8r-0 RaeLg";
+    var current_activities = get_activity_table_values(html_table_element);
+    var total = get_total_dividends_from_activities(current_activities)
+    alert("Total Dividends on this page: $" + total);
+}
+
+function add_calc_button(function_call_on_click) {
+    let searchObj = document.getElementsByClassName("style__filterCol__vGxVW style__root__15AZ1 style__sm8__1y6nR style__xs12__2rudP")[0];
+    let btn = document.createElement("button");
+    btn.innerHTML = "Calculate Dividends";
+    btn.className = "copyBtn";
+    btn.onclick = () => {
+        function_call_on_click()
+    }
+    console.log(searchObj);
+
+    searchObj.insertBefore(btn, searchObj[0]);
+}
+
+function create_calc_button() {
+    add_calc_button(calculate_dividend_amount)
+}
+
+waitForKeyElements (
+    "#root > div > div > div > div:nth-child(2) > div > div.style__root__2dfkG.style__constrain__-PeaO > div:nth-child(2) > div > div",
+    create_calc_button,
+    false
+);
+
+


### PR DESCRIPTION
This adds the functionality to be able to show up the total sum of dividends collected on an M1 Finance Activity page.
This will also add a green button that can be clicked and you should get an alert pop up with the result of total dividends collected.

Button Location:
![image](https://user-images.githubusercontent.com/55446606/113147629-8ee09f80-91f6-11eb-9ed2-80cc33ced9d9.png)

Pop up of total dividends:
![image](https://user-images.githubusercontent.com/55446606/113147693-a61f8d00-91f6-11eb-8f64-5d15a8748b73.png)
