### PR TITLE
feat(PC): add functionality to get portfolio cost basis & dividend yield via requests

### DIFF
--- a/portfolio_tool_scripts/README.md
+++ b/portfolio_tool_scripts/README.md
@@ -38,23 +38,31 @@ Setup Projected Annual Income Table
 
 For Annual Dividend Income
 
-`=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)`
+`=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)`
 
 For Monthly Average Dividend Income
 
-`=AnnualIncomeResult/12` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/12`
+`=AnnualIncomeResult/12` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/12`
 
 For Weekly Average Dividend Income
 
-`=AnnualIncomeResult/52` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/52`
+`=AnnualIncomeResult/52` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/52`
 
 For Daily Average Dividend Income
 
-`=AnnualIncomeResult/365` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/365`
+`=AnnualIncomeResult/365` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/365`
 
 For Hourly Average Dividend Income
 
-`=AnnualIncomeResult/8760` or `=SUMIF(Holdings!J2:J,"FALSE",Holdings!I2:I)/8760`
+`=AnnualIncomeResult/8760` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/8760`
+
+For Portfolio's Dividend Yield On Cost
+
+`=AnnualIncomeResult/SUM(Holdings!E2:E)` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/SUM(Holdings!E2:E)`
+
+For Portfolio's Dividend Yield
+
+`=AnnualIncomeResult/SUM(Holdings!D2:D)` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/SUM(Holdings!D2:D)`
 
 ## utilities.gs
 

--- a/portfolio_tool_scripts/README.md
+++ b/portfolio_tool_scripts/README.md
@@ -56,6 +56,10 @@ For Hourly Average Dividend Income
 
 `=AnnualIncomeResult/8760` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/8760`
 
+For 40 Hourly Work Wage Income
+
+`=AnnualIncomeResult/2080` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/2080`
+
 For Portfolio's Dividend Yield On Cost
 
 `=AnnualIncomeResult/SUM(Holdings!E2:E)` or `=SUMIF(Holdings!L2:L,"FALSE",Holdings!K2:K)/SUM(Holdings!E2:E)`

--- a/portfolio_tool_scripts/main.gs
+++ b/portfolio_tool_scripts/main.gs
@@ -4,6 +4,7 @@ var DIVIDEND_SHEET_NAME = "latest_dividends";
 var HOLDINGS_SHEET_NAME = "Holdings";
 var SETTINGS_SHEET_NAME = "Settings";
 
+
 function initMenu() {
   var ui = SpreadsheetApp.getUi();
   var menu = ui.createMenu("Portfolio Tools");

--- a/portfolio_tool_scripts/main.gs
+++ b/portfolio_tool_scripts/main.gs
@@ -4,7 +4,6 @@ var DIVIDEND_SHEET_NAME = "latest_dividends";
 var HOLDINGS_SHEET_NAME = "Holdings";
 var SETTINGS_SHEET_NAME = "Settings";
 
-
 function initMenu() {
   var ui = SpreadsheetApp.getUi();
   var menu = ui.createMenu("Portfolio Tools");

--- a/portfolio_tool_scripts/populate_holdings.gs
+++ b/portfolio_tool_scripts/populate_holdings.gs
@@ -11,10 +11,10 @@ function populate_holdings() {
   var latest_div_data = get_latest_dividends_data();
 
   Logger.log("Holdings:");
-//  Logger.log(holdings);
+  Logger.log(holdings);
 
   Logger.log("latest_div_data:");
-//  Logger.log(latest_div_data);
+  Logger.log(latest_div_data);
 
   for (var i=0; i < holdings.length; i++) {
     ticker_name = holdings[i]["ticker"];
@@ -47,7 +47,6 @@ function populate_holdings() {
   var ws = get_sheet_object(HOLDINGS_SHEET_NAME);
   ws.getRange("A:AI").clear();
 
-  //var headerRow = Object.keys(holdings[0]);
   var headerRow = ['Ticker', 'Shares', 'Price', 'Value', 'Cost Basis', 'Cost Basis Per Share', 'Yield On Cost', 'Dividend Yield', 'Annual Payout', 'Dividend Amount', 'Projected Payout', 'Dividend Suspended', 'Holding %']
   Logger.log(headerRow);
   ws.appendRow(headerRow);
@@ -73,10 +72,6 @@ function populate_holdings() {
     var row = headerRow.map(function(key){ return dict[key]});
     ws.appendRow(row);
   }
-
-  //Set columns to currency format
-  //var columns = ws.getRange(2,3, ws.getRange("C2").getDataRegion().getLastRow(), ws.getRange("C2").getDataRegion().getLastColumn());
-  //columns.setNumberFormat("$#,##0.00;$(#,##0.00)");
 
 }
 

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -68,6 +68,24 @@ async function get_account_id() {
 
 }
 
+async function get_all_selected_account_ids() {
+    accounts = jQuery('ul[class="menu menu--vertical menu--bordered menu--tiny js-account-selector-menu menu--right"] li').find(":checkbox")
+
+    var account_id_list = [];
+    accounts.each(function( index, element ) {
+        console.log( index + ": checked: " + element.checked + " value: " + element.value );
+        if(!isNaN(element.value) && element.checked) {
+          console.log( "Is an account using: " + element.value + "\n");
+          account_id_list.push(element.value);
+        }
+    });
+
+    console.log("account id list");
+    console.log(account_id_list);
+    return account_id_list
+
+}
+
 function add_copy_button(function_call_on_click) {
       let searchObj = document.getElementsByClassName("pc-input-group  pc-input-group--with-prefix")[0];
       let btn = document.createElement("button");
@@ -104,12 +122,24 @@ async function copy_single_holdings_account() {
 }
 
 async function copy_all_holdings_account() {
-    let account_id = await get_account_id()
-    console.log("user account id tmp: " + account_id);
+    let account_ids = await get_all_selected_account_ids()
+    console.log("user account id tmp: ");
+    console.log(account_ids);
 
 //    let data = 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
 //    let data = 'userAccountIds=%5B79701341%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
-    let data = 'userAccountIds=%5B' + account_id + '%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
+    let data = 'consolidateMultipleAccounts=true' + '&userAccountIds=%5B' + account_ids.join('%2C') + '%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
+    console.log("data being sent: " + data);
+
+//classificationStyles=%5B%22none%22%5D&consolidateMultipleAccounts=true&userAccountIds=%5B79701341%2C79701347%5D&lastServerChangeId=175&csrf=2feb1904-7b40-49ce-b6df-44276fd024ee&apiClient=WEB
+//
+//  classificationStyles: ["none"]
+//  consolidateMultipleAccounts: true
+//  userAccountIds: [79701341,79701347]
+//  lastServerChangeId: 175
+//  csrf: 2feb1904-7b40-49ce-b6df-44276fd024ee
+//  apiClient: WEB
+
 
     console.log(data);
     GM.xmlHttpRequest({

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -120,10 +120,51 @@ function set_to_clipboard(text) {
     temp.remove();
 }
 
-function copy() {
+async function get_account_id() {
+
+    let accountName = document.querySelector("#accountDetails > div > div.appTemplate > div.detailsSection > div > div.nav-secondary.js-secondary-nav > div:nth-child(2) > div.account-details-account-name.js-account-details-account-name.js-closed-text").textContent;
+    console.log("accountName found on html page: " + accountName);
+
+    let data = 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
+    console.log(data);
+		let user_account_id
+    await GM.xmlHttpRequest({
+        method: "POST",
+        url: "https://home.personalcapital.com/api/newaccount/getAccounts2",
+        data: data,
+        headers: {"Content-Type": "application/x-www-form-urlencoded"},
+        onload: function(response) {
+            console.log("Getting account id:");
+            console.log(response.responseText);
+
+            var accounts = JSON.parse(response.responseText);
+            for (const account of accounts["spData"]["accounts"]) {
+                console.log("account name key: " + account["name"] + " account id: " + account["userAccountId"]);
+                if(accountName == account["name"]) {
+                  user_account_id = account["userAccountId"];
+                  break;
+                }
+            }
+
+            console.log("Done Getting account id");
+            console.log("final user account id: " + user_account_id);
+        }
+    });
+
+    return user_account_id
+
+}
+
+
+async function copy() {
+
+    let account_id = await get_account_id()
+    console.log("user account id tmp: " + account_id);
 
 //    let data = 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
-    let data = 'userAccountIds=%5B79701341%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
+//    let data = 'userAccountIds=%5B79701341%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
+    let data = 'userAccountIds=%5B' + account_id + '%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
+
     console.log(data);
     GM.xmlHttpRequest({
         method: "POST",
@@ -140,6 +181,7 @@ function copy() {
 }
 
 function add_copy_button() {
+
     let searchObj = document.getElementsByClassName("pc-input-group  pc-input-group--with-prefix")[0];
     let btn = document.createElement("button");
     btn.innerHTML = "Copy Holdings";

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -1,8 +1,8 @@
 // ==UserScript==
-// @name         Personal Capital Holdings Getter Requests (Testing)
+// @name         Personal Capital Holdings Getter
 // @namespace    http://tampermonkey.net/
-// @version      1.0
-// @description  This will create a button on the holdings tab so that the current positions can be copied to the clipboard as JSON for easy import to GoogleSheets or any other program!
+// @version      2.0
+// @description  This will create a button on the holdings tab so that the current positions (using Requests) can be copied to the clipboard as JSON for easy import to GoogleSheets or any other program!
 // @author       Coding Sensei
 // @include      /^https://home\.personalcapital\.com/page/login/app*/
 // @require      http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js
@@ -103,8 +103,6 @@ async function copy_single_holdings_account() {
     let account_id = await get_account_id()
     console.log("user account id tmp: " + account_id);
 
-//    let data = 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
-//    let data = 'userAccountIds=%5B79701341%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
     let data = 'userAccountIds=%5B' + account_id + '%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
 
     console.log(data);
@@ -126,20 +124,8 @@ async function copy_all_holdings_account() {
     console.log("user account id tmp: ");
     console.log(account_ids);
 
-//    let data = 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
-//    let data = 'userAccountIds=%5B79701341%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
     let data = 'consolidateMultipleAccounts=true' + '&userAccountIds=%5B' + account_ids.join('%2C') + '%5D&' + 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
     console.log("data being sent: " + data);
-
-//classificationStyles=%5B%22none%22%5D&consolidateMultipleAccounts=true&userAccountIds=%5B79701341%2C79701347%5D&lastServerChangeId=175&csrf=2feb1904-7b40-49ce-b6df-44276fd024ee&apiClient=WEB
-//
-//  classificationStyles: ["none"]
-//  consolidateMultipleAccounts: true
-//  userAccountIds: [79701341,79701347]
-//  lastServerChangeId: 175
-//  csrf: 2feb1904-7b40-49ce-b6df-44276fd024ee
-//  apiClient: WEB
-
 
     console.log(data);
     GM.xmlHttpRequest({

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -155,9 +155,21 @@ async function get_account_id() {
 
 }
 
+function add_copy_button(function_call_on_click) {
+      let searchObj = document.getElementsByClassName("pc-input-group  pc-input-group--with-prefix")[0];
+      let btn = document.createElement("button");
+      btn.innerHTML = "Copy Holdings";
+      btn.className = "copyBtn";
+      btn.onclick = () => {
+                function_call_on_click()
+                alert("Finished copying");
+            }
+      console.log(searchObj);
 
-async function copy() {
+      searchObj.insertBefore(btn, searchObj[0]);
+}
 
+async function copy_single_holdings_account() {
     let account_id = await get_account_id()
     console.log("user account id tmp: " + account_id);
 
@@ -177,25 +189,35 @@ async function copy() {
             alert("Finished copying");
         }
     });
-
 }
 
-function add_copy_button() {
+function copy_all_holdings_account() {
+      var html_table_element = "table table--hoverable table--primary table__body--primary pc-holdings-grid qa-datagrid-rows centi  table--actionable";
+      let temp = document.createElement('textarea');
+      document.body.appendChild(temp);
+      var holdings = get_table_holdings(html_table_element);
+      temp.value = convert_holdings_to_json(holdings);
+      temp.select();
+      document.execCommand('copy');
+      temp.remove();
+}
 
-    let searchObj = document.getElementsByClassName("pc-input-group  pc-input-group--with-prefix")[0];
-    let btn = document.createElement("button");
-    btn.innerHTML = "Copy Holdings";
-    btn.className = "copyBtn";
-    btn.onclick = () => {
-        copy();
-    }
-    console.log(searchObj);
+function create_single_account_copy_button() {
+      add_copy_button(copy_single_holdings_account)
+}
 
-    searchObj.insertBefore(btn, searchObj[0]);
+function create_all_account_copy_button() {
+      add_copy_button(copy_all_holdings_account)
 }
 
 waitForKeyElements (
-    "#accountDetails > div > div.appTemplate > div.datagridSection > div > div:nth-child(1) > div > div > div > label",
-    add_copy_button,
-    false
+      "#accountDetails > div > div.appTemplate > div.datagridSection > div > div:nth-child(1) > div > div > div > label",
+      create_single_account_copy_button,
+      false
+);
+
+waitForKeyElements (
+      "#holdings > div > div.gridFrame.offset > div > div:nth-child(1) > div.pc-search-input.pc-u-pl- > div > div > label",
+      create_all_account_copy_button,
+      false
 );

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -40,7 +40,7 @@ async function get_account_id() {
 
     let data = 'lastServerChangeId=-1&csrf=' + csrf + '&apiClient=WEB'
     console.log(data);
-		let user_account_id
+    let user_account_id
     await GM.xmlHttpRequest({
         method: "POST",
         url: "https://home.personalcapital.com/api/newaccount/getAccounts2",


### PR DESCRIPTION
The changes for this PR allow the functionality to show the following

- Cost Basis
- Cost Basis Per Share
- Yield On Cost
- Holding Percentage

Example of Google Sheets:
![image](https://user-images.githubusercontent.com/55446606/149828670-8a899482-d2f8-47f0-a0fe-6821d6fae298.png)

![image](https://user-images.githubusercontent.com/55446606/149828718-fd9e353f-c9a1-4e75-93cc-ac4e0eb32994.png)

This will also allow you to calculate your overall `Portfolio Dividend Yield` at the current moment and also your `Portfolio Dividend Yield On Cost`

The main difference between `Portfolio Dividend Yield` and `Portfolio Dividend Yield On Cost` is that the
`Portfolio Dividend Yield` is the yield if you were to repurchase your portfolio at that current time.
The `Portfolio Dividend Yield` is the dividend yield of your portfolio using your cost basis of your portfolio which removes any unrealized gains. This is typically much higher if you have been investing for a longer time.
![image](https://user-images.githubusercontent.com/55446606/149829282-26a9e16a-9453-4078-b233-db68c20bdaf2.png)

