### PR TITLE
fix(holdings): filter holdings list due to GoogleSheets 50k string limit in cell

### DIFF
--- a/portfolio_tool_scripts/populate_holdings.gs
+++ b/portfolio_tool_scripts/populate_holdings.gs
@@ -2,7 +2,7 @@ function populate_holdings() {
   Logger.log("Populating Holdings")
 
   var settings = get_settings();
-  var holdings = JSON.parse(settings["Portfolio Holdings"])["spData"]["holdings"];
+  var holdings = JSON.parse(settings["Portfolio Holdings"])["holdings"];
 
   var excluded_holdings = settings["Dividend Suspended Holdings"].split(',');
   Logger.log("Holdings to exclude:");

--- a/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
+++ b/tampermonkey_scripts/personal_capital_brokerage_holdings_getter.js
@@ -33,6 +33,29 @@ function set_to_clipboard(text) {
     temp.remove();
 }
 
+function create_filtered_holdings(holdingsText) {
+    var filteredHoldings = {"holdings": []};
+    var unfilteredHoldings = JSON.parse(holdingsText);
+    for (const holding of unfilteredHoldings["spData"]["holdings"]) {
+        var stock = {
+            "quantity": holding["quantity"],
+			"costBasis": holding["costBasis"],
+			"price": holding["price"],
+			"holdingPercentage": holding["holdingPercentage"],
+			"ticker": holding["ticker"],
+			"value": holding["value"],
+			"accountName": holding["accountName"],
+			"holdingType": holding["holdingType"],
+			"userAccountId": holding["userAccountId"],
+			"exchange": holding["exchange"],
+        };
+        filteredHoldings["holdings"].push(stock);
+    }
+
+    return JSON.stringify(filteredHoldings);
+
+}
+
 async function get_account_id() {
 
     let accountName = document.querySelector("#accountDetails > div > div.appTemplate > div.detailsSection > div > div.nav-secondary.js-secondary-nav > div:nth-child(2) > div.account-details-account-name.js-account-details-account-name.js-closed-text").textContent;
@@ -113,7 +136,7 @@ async function copy_single_holdings_account() {
         headers: {"Content-Type": "application/x-www-form-urlencoded"},
         onload: function(response) {
             console.log(response.responseText);
-            set_to_clipboard(response.responseText);
+            set_to_clipboard(create_filtered_holdings(response.responseText));
             alert("Finished copying");
         }
     });
@@ -135,7 +158,7 @@ async function copy_all_holdings_account() {
         headers: {"Content-Type": "application/x-www-form-urlencoded"},
         onload: function(response) {
             console.log(response.responseText);
-            set_to_clipboard(response.responseText);
+            set_to_clipboard(create_filtered_holdings(response.responseText));
             alert("Finished copying");
         }
     });


### PR DESCRIPTION
This fixes the issue of when the holdings string received from Personal Capital exceeds the 50k string limit. The workaround used here is by filtering out unused data in the holdings string. There is still the 50k string limit since that is built-in into the Google Sheets.

![image](https://user-images.githubusercontent.com/55446606/149869665-ac8e72ea-f09a-4ba6-8869-6938f1699219.png)

But this change should greatly reduce the size of the string.